### PR TITLE
Fix bot data persistence on docker

### DIFF
--- a/auto_fix_databases.py
+++ b/auto_fix_databases.py
@@ -9,44 +9,63 @@ def fix_all_databases():
     """Fix all database files before starting the bot"""
     print("🔧 Starting automatic database fix...")
     
-    # Fix all database and session files
+    # Discover data and sessions directories
+    data_dir = os.getenv('DATA_DIR', '/app/data')
+    sessions_dir = os.getenv('SESSIONS_DIR', os.path.join(data_dir, 'sessions'))
+
+    # Build list of candidate files
+    scan_dirs = ['.', data_dir, sessions_dir]
     patterns = ['*.db', '*.session', 'telegram_bot.db*']
-    for pattern in patterns:
-        for db_file in glob.glob(pattern):
-            if os.path.exists(db_file) and not db_file.endswith('.backup'):
+    files_to_fix = set()
+    for base in scan_dirs:
+        try:
+            for pattern in patterns:
+                for path in glob.glob(os.path.join(base, pattern)):
+                    if os.path.exists(path) and not path.endswith('.backup'):
+                        files_to_fix.add(os.path.abspath(path))
+        except Exception:
+            pass
+
+    # Fix all database and session files
+    for db_file in sorted(files_to_fix):
+        try:
+            print(f"🔨 Fixing {db_file}...")
+            
+            # Ensure parent directory exists and set permissions to 666
+            try:
+                os.makedirs(os.path.dirname(db_file), exist_ok=True)
+            except Exception:
+                pass
+            os.chmod(db_file, 0o666)
+            
+            # Fix SQLite database settings
+            if db_file.endswith('.db') or db_file.endswith('.session'):
+                conn = sqlite3.connect(db_file, timeout=30)
                 try:
-                    print(f"🔨 Fixing {db_file}...")
-                    
-                    # Set permissions to 666
-                    os.chmod(db_file, 0o666)
-                    
-                    # Fix SQLite database settings
-                    if db_file.endswith('.db') or db_file.endswith('.session'):
-                        conn = sqlite3.connect(db_file, timeout=30)
-                        try:
-                            conn.execute('PRAGMA journal_mode=DELETE')
-                            conn.execute('PRAGMA synchronous=NORMAL') 
-                            conn.execute('PRAGMA temp_store=MEMORY')
-                            conn.execute('PRAGMA locking_mode=NORMAL')
-                            conn.commit()
-                            print(f"✅ Fixed database settings for {db_file}")
-                        except Exception as e:
-                            print(f"⚠️ Warning fixing {db_file}: {e}")
-                        finally:
-                            conn.close()
-                    
+                    conn.execute('PRAGMA journal_mode=DELETE')
+                    conn.execute('PRAGMA synchronous=NORMAL') 
+                    conn.execute('PRAGMA temp_store=MEMORY')
+                    conn.execute('PRAGMA locking_mode=NORMAL')
+                    conn.commit()
+                    print(f"✅ Fixed database settings for {db_file}")
                 except Exception as e:
-                    print(f"❌ Error with {db_file}: {e}")
+                    print(f"⚠️ Warning fixing {db_file}: {e}")
+                finally:
+                    conn.close()
+            
+        except Exception as e:
+            print(f"❌ Error with {db_file}: {e}")
     
     # Clean up journal/wal files
     cleanup_patterns = ['*.db-wal', '*.db-shm', '*.session-journal', '*.session-wal']
-    for pattern in cleanup_patterns:
-        for file_path in glob.glob(pattern):
-            try:
-                os.remove(file_path)
-                print(f"🗑️ Removed {file_path}")
-            except:
-                pass
+    for base in scan_dirs:
+        for pattern in cleanup_patterns:
+            for file_path in glob.glob(os.path.join(base, pattern)):
+                try:
+                    os.remove(file_path)
+                    print(f"🗑️ Removed {file_path}")
+                except:
+                    pass
     
     print("✅ Database fix complete!")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - PYTHONUNBUFFERED=1
       - PYTHONDONTWRITEBYTECODE=1
       - TZ=UTC
+      - DATA_DIR=/app/data
+      - SQLITE_DB_PATH=/app/data/telegram_bot.db
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs


### PR DESCRIPTION
Initiate fix for data persistence issue in Docker deployments.

When deployed on Northflank via Docker, the bot loses all session and database data (`telegram_bot.db`) upon restart. This PR aims to ensure data persistence by configuring Docker volumes correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-167d2eeb-2029-49d7-8184-ee4b00a43efa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-167d2eeb-2029-49d7-8184-ee4b00a43efa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

