### PR TITLE
Handle invalid integer literal errors

### DIFF
--- a/bot_package/bot_simple.py
+++ b/bot_package/bot_simple.py
@@ -2980,7 +2980,7 @@ class SimpleTelegramBot:
                 parts = data.split("_")
                 if len(parts) >= 4:
                     try:
-                        task_id = int(parts[3])
+                        task_id = int(parts[-1])
                         settings = self.db.get_message_settings(task_id)
                         new_val = not bool(settings.get('apply_header_to_texts', True))
                         self.db.update_message_settings_scope(task_id, apply_header_to_texts=new_val)
@@ -2993,7 +2993,7 @@ class SimpleTelegramBot:
                 parts = data.split("_")
                 if len(parts) >= 4:
                     try:
-                        task_id = int(parts[3])
+                        task_id = int(parts[-1])
                         settings = self.db.get_message_settings(task_id)
                         new_val = not bool(settings.get('apply_header_to_media', True))
                         self.db.update_message_settings_scope(task_id, apply_header_to_media=new_val)
@@ -3006,7 +3006,7 @@ class SimpleTelegramBot:
                 parts = data.split("_")
                 if len(parts) >= 4:
                     try:
-                        task_id = int(parts[3])
+                        task_id = int(parts[-1])
                         settings = self.db.get_message_settings(task_id)
                         new_val = not bool(settings.get('apply_footer_to_texts', True))
                         self.db.update_message_settings_scope(task_id, apply_footer_to_texts=new_val)
@@ -3019,7 +3019,7 @@ class SimpleTelegramBot:
                 parts = data.split("_")
                 if len(parts) >= 4:
                     try:
-                        task_id = int(parts[3])
+                        task_id = int(parts[-1])
                         settings = self.db.get_message_settings(task_id)
                         new_val = not bool(settings.get('apply_footer_to_media', True))
                         self.db.update_message_settings_scope(task_id, apply_footer_to_media=new_val)


### PR DESCRIPTION
Update `task_id` parsing in toggle handlers to fix `invalid literal for int()` errors.

The previous parsing logic for callback data like `toggle_footer_scope_texts_{task_id}` incorrectly used `parts[3]` to extract `task_id`. This resulted in 'texts' or 'media' being passed to `int()`, causing an `invalid literal` error. Changing to `parts[-1]` ensures the correct `task_id` is always retrieved from the end of the split string.

---
<a href="https://cursor.com/background-agent?bcId=bc-7680be47-bd91-4f51-aebb-ab9d7f2639fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7680be47-bd91-4f51-aebb-ab9d7f2639fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

